### PR TITLE
Added missing 2h window

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ time series:
 - `job:slo_error:ratio5m`
 - `job:slo_error:ratio30m`
 - `job:slo_error:ratio1h`
+- `job:slo_error:ratio2h`
 - `job:slo_error:ratio6h`
 - `job:slo_error:ratio1d`
 - `job:slo_error:ratio7d`

--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -90,6 +90,13 @@ groups:
       )
     labels:
       name: PaymentsServiceSearchErrors
+  - record: job:slo_error_rate_errors:rate2h
+    expr: |
+      sum by (namespace, release) (
+        rate(http_request_duration_seconds_count{app="payments-service", handler=~"Routes::(Admin)?Search", status=~"5.."}[2h])
+      )
+    labels:
+      name: PaymentsServiceSearchErrors
   - record: job:slo_error_rate_errors:rate6h
     expr: |
       sum by (namespace, release) (
@@ -153,6 +160,13 @@ groups:
       )
     labels:
       name: PaymentsServiceSearchErrors
+  - record: job:slo_error_rate_total:rate2h
+    expr: |
+      sum by (namespace, release) (
+        rate(http_request_duration_seconds_count{app="payments-service", handler=~"Routes::(Admin)?Search"}[2h])
+      )
+    labels:
+      name: PaymentsServiceSearchErrors
   - record: job:slo_error_rate_total:rate6h
     expr: |
       sum by (namespace, release) (
@@ -199,6 +213,8 @@ groups:
     expr: avg_over_time(job:slo_batch_error:interval[30m])
   - record: job:slo_error:ratio1h
     expr: avg_over_time(job:slo_batch_error:interval[1h])
+  - record: job:slo_error:ratio2h
+    expr: avg_over_time(job:slo_batch_error:interval[2h])
   - record: job:slo_error:ratio6h
     expr: avg_over_time(job:slo_batch_error:interval[6h])
   - record: job:slo_error:ratio1d
@@ -221,6 +237,9 @@ groups:
   - record: job:slo_error:ratio1h
     expr: ((job:slo_error_rate_errors:rate1h) or (0 * job:slo_error_rate_total:rate1h))
       / job:slo_error_rate_total:rate1h
+  - record: job:slo_error:ratio2h
+    expr: ((job:slo_error_rate_errors:rate2h) or (0 * job:slo_error_rate_total:rate2h))
+      / job:slo_error_rate_total:rate2h
   - record: job:slo_error:ratio6h
     expr: ((job:slo_error_rate_errors:rate6h) or (0 * job:slo_error_rate_total:rate6h))
       / job:slo_error_rate_total:rate6h

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -43,7 +43,7 @@ var (
 	TemplateRules = []rulefmt.Rule{}
 
 	// AlertWindows are common interval windows we want to precompute
-	AlertWindows = []string{"1m", "5m", "30m", "1h", "6h", "1d", "3d", "7d", "28d"}
+	AlertWindows = []string{"1m", "5m", "30m", "1h", "2h", "6h", "1d", "3d", "7d", "28d"}
 
 	// AlertRules every SLO type produces rules that terminate in job:slo_error:ratio<I> and
 	// job:slo_error_budget's. Together, we can use these rules to power generic


### PR DESCRIPTION
The detection 2h windows is required to implement the following
detection sensitivity table:

| Alert | Long Window | Short Window | `for` Duration | Burn Rate Factor | Error Budget Consumed |
| --- | --- | --- | --- | --- | --- |
| Page | 1h | 5m | 2m | 14.4 | 2% |
| Page | 6h | 30m | 15m | 6 | 5% |
| Ticket | 1d | 2h | 1h | 3 | 10% |
| Ticket | 3d | 6h | 1h | 1 | 10% |


See https://github.com/gocardless/slo-builder#alerting for detail
context