### PR TITLE
Alert SLOErrorBudgetFastBurn missing labels

### DIFF
--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -634,10 +634,10 @@ groups:
     expr: (job:slo_latency_total:rate28d - job:slo_latency_observation:rate28d) /
       job:slo_latency_total:rate28d
   - alert: SLOErrorBudgetFastBurn
-    expr: "\n(\n  job:slo_error:ratio1h > on(name) (14.4 * job:slo_error_budget:ratio)\nand\n
-      \ job:slo_error:ratio5m > on(name) (14.4 * job:slo_error_budget:ratio)\n)\nor\n(\n
-      \ job:slo_error:ratio6h  > on(name) (6.0 * job:slo_error_budget:ratio)\nand\n
-      \ job:slo_error:ratio30m > on(name) (6.0 * job:slo_error_budget:ratio)\n)\n\t\t\t"
+    expr: "\n(\n  job:slo_error:ratio1h > on(name) group_left() (14.4 * job:slo_error_budget:ratio)\nand\n
+      \ job:slo_error:ratio5m > on(name) group_left() (14.4 * job:slo_error_budget:ratio)\n)\nor\n(\n
+      \ job:slo_error:ratio6h > on(name) group_left() (6.0 * job:slo_error_budget:ratio)\nand\n
+      \ job:slo_error:ratio30m > on(name) group_left() (6.0 * job:slo_error_budget:ratio)\n)\n\t\t\t"
     for: 1m
     labels:
       severity: ticket

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -58,15 +58,15 @@ var (
 			},
 			Expr: `
 (
-  job:slo_error:ratio1h > on(name) (14.4 * job:slo_error_budget:ratio)
+  job:slo_error:ratio1h > on(name) group_left() (14.4 * job:slo_error_budget:ratio)
 and
-  job:slo_error:ratio5m > on(name) (14.4 * job:slo_error_budget:ratio)
+  job:slo_error:ratio5m > on(name) group_left() (14.4 * job:slo_error_budget:ratio)
 )
 or
 (
-  job:slo_error:ratio6h  > on(name) (6.0 * job:slo_error_budget:ratio)
+  job:slo_error:ratio6h > on(name) group_left() (6.0 * job:slo_error_budget:ratio)
 and
-  job:slo_error:ratio30m > on(name) (6.0 * job:slo_error_budget:ratio)
+  job:slo_error:ratio30m > on(name) group_left() (6.0 * job:slo_error_budget:ratio)
 )
 			`,
 		},


### PR DESCRIPTION
`job:slo_error:ratio<I>` can have multiple labels that are not in `job:slo_error_budget:ratio`.

To keep those labels in the alerts the `group_left` modifier is needed it.