### PR TITLE
Adds request classes to the latency SLO template

### DIFF
--- a/example-definitions.yaml
+++ b/example-definitions.yaml
@@ -35,7 +35,7 @@ definitions:
     definition:
       name: AdminVerificationLatency90
       budget: 0.1
-      requestClass: "1"
+      requestClass: "ok"
       total: |
         sum by (namespace, release) (
           rate(http_request_duration_seconds_count{app="payments-service", handler="Routes::AdminVerifications::Index"}[%s])
@@ -49,7 +49,7 @@ definitions:
     definition:
       name: AdminVerificationLatency99
       budget: 0.01
-      requestClass: "2.5"
+      requestClass: "slow+"
       total: |
         sum by (namespace, release) (
           rate(http_request_duration_seconds_count{app="payments-service", handler="Routes::AdminVerifications::Index"}[%s])

--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -211,7 +211,7 @@ groups:
         sum by (namespace, release) (
           rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="%s"}[%s])
         )
-      request_class: "1"
+      request_class: ok
       total: |
         sum by (namespace, release) (
           rate(http_request_duration_seconds_count{app="payments-service", handler="Routes::AdminVerifications::Index"}[%s])
@@ -227,7 +227,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate5m
     expr: |
       sum by (namespace, release) (
@@ -235,7 +235,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate30m
     expr: |
       sum by (namespace, release) (
@@ -243,7 +243,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate1h
     expr: |
       sum by (namespace, release) (
@@ -251,7 +251,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate2h
     expr: |
       sum by (namespace, release) (
@@ -259,7 +259,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate6h
     expr: |
       sum by (namespace, release) (
@@ -267,7 +267,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate1d
     expr: |
       sum by (namespace, release) (
@@ -275,7 +275,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate3d
     expr: |
       sum by (namespace, release) (
@@ -283,7 +283,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate7d
     expr: |
       sum by (namespace, release) (
@@ -291,7 +291,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_total:rate28d
     expr: |
       sum by (namespace, release) (
@@ -299,7 +299,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate1m
     expr: |
       sum by (namespace, release) (
@@ -307,7 +307,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate5m
     expr: |
       sum by (namespace, release) (
@@ -315,7 +315,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate30m
     expr: |
       sum by (namespace, release) (
@@ -323,7 +323,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate1h
     expr: |
       sum by (namespace, release) (
@@ -331,7 +331,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate2h
     expr: |
       sum by (namespace, release) (
@@ -339,7 +339,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate6h
     expr: |
       sum by (namespace, release) (
@@ -347,7 +347,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate1d
     expr: |
       sum by (namespace, release) (
@@ -355,7 +355,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate3d
     expr: |
       sum by (namespace, release) (
@@ -363,7 +363,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate7d
     expr: |
       sum by (namespace, release) (
@@ -371,7 +371,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_latency_observation:rate28d
     expr: |
       sum by (namespace, release) (
@@ -379,7 +379,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency90
-      request_class: "1"
+      request_class: ok
   - record: job:slo_definition:none
     expr: "1"
     labels:
@@ -389,7 +389,7 @@ groups:
         sum by (namespace, release) (
           rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="%s"}[%s])
         )
-      request_class: "2.5"
+      request_class: slow+
       total: |
         sum by (namespace, release) (
           rate(http_request_duration_seconds_count{app="payments-service", handler="Routes::AdminVerifications::Index"}[%s])
@@ -405,7 +405,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate5m
     expr: |
       sum by (namespace, release) (
@@ -413,7 +413,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate30m
     expr: |
       sum by (namespace, release) (
@@ -421,7 +421,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate1h
     expr: |
       sum by (namespace, release) (
@@ -429,7 +429,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate2h
     expr: |
       sum by (namespace, release) (
@@ -437,7 +437,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate6h
     expr: |
       sum by (namespace, release) (
@@ -445,7 +445,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate1d
     expr: |
       sum by (namespace, release) (
@@ -453,7 +453,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate3d
     expr: |
       sum by (namespace, release) (
@@ -461,7 +461,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate7d
     expr: |
       sum by (namespace, release) (
@@ -469,7 +469,7 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_total:rate28d
     expr: |
       sum by (namespace, release) (
@@ -477,87 +477,87 @@ groups:
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate1m
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[1m])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[1m])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate5m
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[5m])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[5m])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate30m
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[30m])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[30m])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate1h
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[1h])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[1h])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate2h
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[2h])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[2h])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate6h
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[6h])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[6h])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate1d
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[1d])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[1d])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate3d
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[3d])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[3d])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate7d
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[7d])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[7d])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_latency_observation:rate28d
     expr: |
       sum by (namespace, release) (
-        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="2.5"}[28d])
+        rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="5"}[28d])
       )
     labels:
       name: AdminVerificationLatency99
-      request_class: "2.5"
+      request_class: slow+
   - record: job:slo_batch_error:interval
     expr: "\n1.0 - clamp_max(\n  job:slo_batch_throughput:interval / job:slo_batch_throughput_target:max,\n
       \ 1.0\n)\n\t\t\t"

--- a/pkg/templates/latency.go
+++ b/pkg/templates/latency.go
@@ -20,6 +20,33 @@ var (
 	)
 )
 
+// This map contains a mapping between request classes and the latency buckets
+// we use in Prometheus. 
+// 
+// It assumes that the observation metric is an histogram where the following
+// buckets exist: 0.1, 0.25, 0.5, 1, 2.5, 5 and 10.
+//
+// The bucket values were chosen based on the performance of payments-service
+// over a  month. The spreadsheet linked below includes the latency percentiles
+// of payments-service for each one of the routes over a month. We chose the
+// bucket values below keeping in mind that:
+// - We wanted to choose a set of buckets we could use across our 95th and 99th
+//   latency percentiles
+// - The buckets are generic and have an even distribution across all of routes,
+//   i.e. all buckets apply to an similar number of routes so that there are no
+//   special cases
+//
+// https://docs.google.com/spreadsheets/d/1CAe6gpgZdjYjBy44bdYSBD0ZA8yxSkMkiqjLiZ_8NRo/edit#gid=15427288
+var requestClassToLatencyBucket = map[string]string{
+  "fast++": "0.1", // 100 ms
+  "fast+": "0.25", // 250 ms
+  "fast": "0.5",   // 500 ms
+  "ok": "1",       // 1s
+  "slow": "2.5",   // 2.5s
+  "slow+": "5",    // 5s
+  "slow++": "10",  // 10s
+}
+
 func init() {
 	MustRegisterTemplate(LatencySLO{}, LatencyTemplateRules...)
 }
@@ -59,7 +86,8 @@ func (l LatencySLO) Rules() []rulefmt.Rule {
 		forIntervals(AlertWindows, rulefmt.Rule{
 			Record: "job:slo_latency_observation:rate%s",
 			Labels: l.joinLabels(map[string]string{"request_class": l.RequestClass}),
-			Expr:   fmt.Sprintf(l.Observation, l.RequestClass, "%s"),
+			// TODO what if the class is invalid? Do we want to return an error?
+			Expr:   fmt.Sprintf(l.Observation, requestClassToLatencyBucket[l.RequestClass], "%s"),
 		}),
 	)
 }


### PR DESCRIPTION
This PR adds request classes to the latency SLO template.

These classes map human readable names to latency values that we can alert on.

Also, this is my very first go PR, so let me know if something is not done the go way.