### PR TITLE
Support additional labels in the SLO definition

### DIFF
--- a/example-definitions.yaml
+++ b/example-definitions.yaml
@@ -17,6 +17,8 @@ definitions:
         sum by (namespace, release) (
           rate(paysvc_mark_payments_as_paid_marked_as_paid_total[1m])
         ) > 0
+      labels:
+        channel: slo-alerts
 
   - template: ErrorRateSLO
     definition:
@@ -30,6 +32,8 @@ definitions:
         sum by (namespace, release) (
           rate(http_request_duration_seconds_count{app="payments-service", handler=~"Routes::(Admin)?Search"}[%s])
         )
+      labels:
+        channel: slo-alerts
 
   - template: LatencySLO
     definition:
@@ -58,3 +62,5 @@ definitions:
         sum by (namespace, release) (
           rate(http_request_duration_seconds_bucket{app="payments-service", handler="Routes::AdminVerifications::Index", le="%s"}[%s])
         )
+      labels:
+        channel: slo-alerts

--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -24,6 +24,11 @@ groups:
     expr: "0.100000"
     labels:
       name: MarkPaymentsAsPaidMeetsDeadline
+  - record: job:slo_labels_info
+    expr: "1"
+    labels:
+      channel: slo-alerts
+      name: MarkPaymentsAsPaidMeetsDeadline
   - record: job:slo_batch_volume:max
     expr: |
       1.5 * max_over_time(
@@ -63,6 +68,11 @@ groups:
   - record: job:slo_error_budget:ratio
     expr: "0.001000"
     labels:
+      name: PaymentsServiceSearchErrors
+  - record: job:slo_labels_info
+    expr: "1"
+    labels:
+      channel: slo-alerts
       name: PaymentsServiceSearchErrors
   - record: job:slo_error_rate_errors:rate1m
     expr: |
@@ -221,6 +231,10 @@ groups:
         )
   - record: job:slo_error_budget:ratio
     expr: "0.100000"
+    labels:
+      name: AdminVerificationLatency90
+  - record: job:slo_labels_info
+    expr: "1"
     labels:
       name: AdminVerificationLatency90
   - record: job:slo_latency_total:rate1m
@@ -401,6 +415,11 @@ groups:
   - record: job:slo_error_budget:ratio
     expr: "0.010000"
     labels:
+      name: AdminVerificationLatency99
+  - record: job:slo_labels_info
+    expr: "1"
+    labels:
+      channel: slo-alerts
       name: AdminVerificationLatency99
   - record: job:slo_latency_total:rate1m
     expr: |

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.12
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/kit v0.9.0
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/prometheus/common v0.6.0

--- a/pkg/templates/base.go
+++ b/pkg/templates/base.go
@@ -20,6 +20,7 @@ type SLO interface {
 //
 // - job:slo_definition:none{name, budget, template_labels...}
 // - job:slo_error_budget:ratio{name}
+// - job:slo_labels_info{name, definition_labels...}
 //
 // The `slo_definition` is to track how the definition of an SLO changes over time. By
 // recording the parameters provided to the template in a metric, it's easy to understand
@@ -28,9 +29,14 @@ type SLO interface {
 // The `slo_error_budget` rule is required to power generic alerting rules. Every template
 // will eventually produce job:slo_error:ratio<I> rules, which together with the error
 // budget can determine when to fire alerts.
+//
+// The `slo_labels_info` provides additional labels that can be useful in the
+// alerting rules.
+//
 type baseSLO struct {
-	Name   string  `json:"name"`
-	Budget float64 `json:"budget"`
+	Name   string            `json:"name"`
+	Budget float64           `json:"budget"`
+	Labels map[string]string `json:"labels"`
 }
 
 func (b baseSLO) GetName() string {
@@ -52,6 +58,11 @@ func (b baseSLO) Rules(additionals ...map[string]string) []rulefmt.Rule {
 			Record: "job:slo_error_budget:ratio",
 			Labels: b.joinLabels(),
 			Expr:   fmt.Sprintf("%f", b.Budget),
+		},
+		rulefmt.Rule{
+			Record: "job:slo_labels_info",
+			Labels: b.joinLabels(b.Labels),
+			Expr:   "1",
 		},
 	}
 }


### PR DESCRIPTION
Provides a new metric `job:slo_labels_info` with the additional labels