### PR TITLE
Combine SLO alerts with `job:slo_labels_info`

### DIFF
--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -657,18 +657,20 @@ groups:
     expr: (job:slo_latency_total:rate28d - job:slo_latency_observation:rate28d) /
       job:slo_latency_total:rate28d
   - alert: SLOErrorBudgetFastBurn
-    expr: "\n(\n  job:slo_error:ratio1h > on(name) group_left() (14.4 * job:slo_error_budget:ratio)\nand\n
+    expr: "\n((\n  job:slo_error:ratio1h > on(name) group_left() (14.4 * job:slo_error_budget:ratio)\nand\n
       \ job:slo_error:ratio5m > on(name) group_left() (14.4 * job:slo_error_budget:ratio)\n)\nor\n(\n
       \ job:slo_error:ratio6h > on(name) group_left() (6.0 * job:slo_error_budget:ratio)\nand\n
-      \ job:slo_error:ratio30m > on(name) group_left() (6.0 * job:slo_error_budget:ratio)\n)\n\t\t\t"
+      \ job:slo_error:ratio30m > on(name) group_left() (6.0 * job:slo_error_budget:ratio)\n))
+      * on(name) group_left(channel) job:slo_labels_info\n\t\t\t"
     for: 1m
     labels:
       severity: ticket
   - alert: SLOErrorBudgetSlowBurn
-    expr: "\n(\n  job:slo_error:ratio1d > on(name) group_left() (3.0 * job:slo_error_budget:ratio)\nand\n
+    expr: "\n((\n  job:slo_error:ratio1d > on(name) group_left() (3.0 * job:slo_error_budget:ratio)\nand\n
       \ job:slo_error:ratio2h > on(name) group_left() (3.0 * job:slo_error_budget:ratio)\n)\nor\n(\n
       \ job:slo_error:ratio3d > on(name) group_left() (1.0 * job:slo_error_budget:ratio)\nand\n
-      \ job:slo_error:ratio6h > on(name) group_left() (1.0 * job:slo_error_budget:ratio)\n)\n\t\t\t"
+      \ job:slo_error:ratio6h > on(name) group_left() (1.0 * job:slo_error_budget:ratio)\n))
+      * on(name) group_left(channel) jobs:slo_labels_info\n\t\t\t"
     for: 1h
     labels:
       severity: ticket

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -57,7 +57,7 @@ var (
 				"severity": "ticket", // TODO: "page",
 			},
 			Expr: `
-(
+((
   job:slo_error:ratio1h > on(name) group_left() (14.4 * job:slo_error_budget:ratio)
 and
   job:slo_error:ratio5m > on(name) group_left() (14.4 * job:slo_error_budget:ratio)
@@ -67,7 +67,7 @@ or
   job:slo_error:ratio6h > on(name) group_left() (6.0 * job:slo_error_budget:ratio)
 and
   job:slo_error:ratio30m > on(name) group_left() (6.0 * job:slo_error_budget:ratio)
-)
+)) * on(name) group_left(channel) job:slo_labels_info
 			`,
 		},
 		rulefmt.Rule{
@@ -77,7 +77,7 @@ and
 				"severity": "ticket",
 			},
 			Expr: `
-(
+((
   job:slo_error:ratio1d > on(name) group_left() (3.0 * job:slo_error_budget:ratio)
 and
   job:slo_error:ratio2h > on(name) group_left() (3.0 * job:slo_error_budget:ratio)
@@ -87,7 +87,7 @@ or
   job:slo_error:ratio3d > on(name) group_left() (1.0 * job:slo_error_budget:ratio)
 and
   job:slo_error:ratio6h > on(name) group_left() (1.0 * job:slo_error_budget:ratio)
-)
+)) * on(name) group_left(channel) jobs:slo_labels_info
 			`,
 		},
 	}


### PR DESCRIPTION
It keeps all labels from the left with the addition of the channel
label. See #9

We might want to make this configurable with sensible defaults using cli
flags.