### PR TITLE
Add name to job:slo_batch_throughput_target:max

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,23 @@
 ---
 version: 2
 
+references:
+  docker_golang: &docker_golang
+    docker:
+      - image: golang:1.14.5
+    working_directory: /go/src/github.com/gocardless/slo-builder
+
 jobs:
   promtool:
-    docker:
-      - image: golang:1.12
-        environment:
-          GO111MODULE: "ON"
-    working_directory: /go/src/github.com/gocardless/slo-builder
+    <<: *docker_golang
     steps:
       - checkout
       - run:
           name: promtool check rules
           command: |
             curl --connect-timeout 15 --retry 3 -sfL \
-              https://github.com/prometheus/prometheus/releases/download/v2.11.1/prometheus-2.11.1.linux-amd64.tar.gz \
-              | tar --strip-components=1 -xzf - prometheus-2.11.1.linux-amd64/promtool
+              https://github.com/prometheus/prometheus/releases/download/v2.20.1/prometheus-2.20.1.linux-amd64.tar.gz \
+              | tar --strip-components=1 -xzf - prometheus-2.20.1.linux-amd64/promtool
             ./promtool check rules *-rules.yaml
 
 workflows:

--- a/example-rules.yaml
+++ b/example-rules.yaml
@@ -41,7 +41,7 @@ groups:
     labels:
       name: MarkPaymentsAsPaidMeetsDeadline
   - record: job:slo_batch_throughput_target:max
-    expr: job:slo_batch_volume:max / 7200
+    expr: job:slo_batch_volume:max{name="MarkPaymentsAsPaidMeetsDeadline"} / 7200
     labels:
       name: MarkPaymentsAsPaidMeetsDeadline
   - record: job:slo_batch_throughput:interval

--- a/pkg/templates/batch_processing.go
+++ b/pkg/templates/batch_processing.go
@@ -87,7 +87,7 @@ func (b BatchProcessingSLO) Rules() []rulefmt.Rule {
 			Record: "job:slo_batch_throughput_target:max",
 			Labels: b.joinLabels(),
 			Expr: fmt.Sprintf(
-				`job:slo_batch_volume:max / %d`, time.Duration(b.Deadline)/time.Second,
+				`job:slo_batch_volume:max{name="%s"} / %d`, b.Name, time.Duration(b.Deadline)/time.Second,
 			),
 		},
 		rulefmt.Rule{


### PR DESCRIPTION
Currently each batch processing SLO creates a recording rule that looks like this:
```
record: job:slo_batch_throughput_target:max
expr: job:slo_batch_volume:max
  / 600
labels:
  name: GenerateEURMerchantPayoutsMeetsDeadline
```

This expression is relying on another recording rule that all batch
processing rule SLOs create, `job:slo_batch_volume:max`.

`job:slo_batch_volume:max` contains all the results for all rules, eg:

```
{currency="EUR",name="MarkEURPaymentsAsPaidMeetsDeadline"}
{currency="GBP",name="GenerateGBPMerchantPayoutsMeetsDeadline"}
```

As seen above in `job:slo_batch_throughput_target:max` we apply the SLO
label name and as all results are returned we will overwrite all name labels.

This rightly leads to the error:
`vector contains metrics with the same labelset after applying rule
labels`

We need to ensure that we filter the results of job:slo_batch_volume:max
by the name of the SLO to prevent this and record correctly.

eg:
```
record: job:slo_batch_throughput_target:max
expr: job:slo_batch_volume:max{name="GenerateEURMerchantPayoutsMeetsDeadline"}
  / 600
labels:
  name: GenerateEURMerchantPayoutsMeetsDeadline
```