### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ without requiring in-depth Prometheus knowledge.
 Run the following command **outside of a `go.mod` repository** to install the `slo-builder` binary.
 
 ```
-go get -u github.com/gocardless/slo-builder/cmd/slo-builder
+go install github.com/gocardless/slo-builder/cmd/slo-builder@latest
 ```
 
 You also need to ensure your `go/bin` directory is available in your `$PATH`:


### PR DESCRIPTION
Follow new `golang` conventions. Context https://golang.org/doc/go-get-install-deprecation

```
$ go get -u github.com/gocardless/slo-builder/cmd/slo-builder       

go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```